### PR TITLE
fix: Print correct order in getSql

### DIFF
--- a/src/queries/BaseQuery.ts
+++ b/src/queries/BaseQuery.ts
@@ -228,7 +228,7 @@ export class BaseQuery<KT extends BaseEntity> {
         }
 
         for (const order of this.query.orders) {
-            sql += ` ORDER BY ${order.name} ${order.sign ? "DESC" : "ASC"}`;
+            sql += ` ORDER BY ${order.name} ${order.sign === '-' ? "DESC" : "ASC"}`;
         }
 
         if (this.query.limitVal > 0) {


### PR DESCRIPTION
order.sign is either - or +, but is being treated as a boolean value in the order part of getSql. This makes it so all queries will have "ORDER BY X DESC" in if they have any ordering in the getSql output.